### PR TITLE
Correct mime type for JSON Feed to JF2 conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@
                 <li>Rename "mime-type" to "content-type".</li>
                 <li>Keep the "url" property as is.</li>
                 <li>If the "content-type" field begins with "video/", add the item to the "video" property array.</li>
-                <li>If the "content-type" field begins with "photo/", add the item to the "photo" property array.</li>
+                <li>If the "content-type" field begins with "image/", add the item to the "photo" property array.</li>
               </ol>
 
             </li>


### PR DESCRIPTION
Images use mime-types starting with `image/`, not `photo/`.