### PR TITLE
provide a path for new folks to contribute via W3C Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # JF2 Editor's Draft
 Simplified JSON format of post streams
 
-Contributions to this specification are governed by the W3C IPR Policy. Pull requests will be accepted only if the submitter was a member of the W3C Social WG but issues can be opened by anyone. 
+Contributions to this specification are governed by the W3C IPR Policy. 
+Pull requests will be accepted only if the submitter was a member of the W3C Social WG, 
+or has followed the instructions on [W3C’s GitHub Contributor Management guide](https://www.w3.org/guide/github/repo-management.html) 
+to associate their GitHub account with their W3C account and made IPR agreements accordingly.
+
+Issues can be opened by anyone. 


### PR DESCRIPTION
link to W3C’s GitHub Contributor Management guide as another way people can agree to the necessary agreements to create PRs. suggestions/copyedits welcome.