### PR TITLE
editorial: fix markup, name typos, add authors names

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,9 @@
       <p>
         This document is an attempt to unify various simplified versions of the
         microformats2 representative JSON format.  As such, much of this document
-        is likely to change as various implementations contribute input.
+        is likely to change as various implementations contribute input. 
+        — <span class="h-card vcard"><span class="p-name fn">Kevin Marks</span></span> 
+        &amp; <span class="h-card vcard"><span class="p-name fn">Bebe Roberts</span></span>
       </p>
     </section>
     
@@ -137,7 +139,7 @@
       by anything else.
       </p>
       <p>
-      <a href="https://github.com/kylewm/mf2util">mf2util</a> is a utility library that provides a layer on top
+      <a href="https://github.com/karadaisy/mf2util">mf2util</a> is a utility library that provides a layer on top
       of microformats processing.  The library returns only a simple JSON object and strips
       off any unnecessary information leaving the library user only the most essential information.
       </p>
@@ -976,7 +978,7 @@
 
           </ul>
           <p>
-            It may be benefitial to drop any properties other than those mentioned to avoid conflicts with any future [[microformats2]] properties.
+            It may be beneficial to drop any properties other than those mentioned to avoid conflicts with any future [[microformats2]] properties.
           </p>
 
 
@@ -1093,7 +1095,7 @@
         <tr>
           <td>Contact: </td>
           <td>
-            Ben Roberts &lt;<a href="mailto:ben@thatmustbe.me">ben@thatmustbe.me</a>&gt;
+            Bebe Roberts &lt;<a href="mailto:ben@thatmustbe.me">ben@thatmustbe.me</a>&gt;
           </td>
         </tr>
         </table>
@@ -1178,19 +1180,19 @@
         <p>
           The authors wish to thank the Microformats, IndieWeb, Pump.io, and Activity Streams communities for their continued work
           in building the social web and helping define standards such as this one.  This includes, but is certainly not limited to, 
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://aaronparecki.com/">Aaron Parecki</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://strugee.net/">AJ Jordan</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://bengo.is/">Benjamin Goering</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://inessential.com/">Brent Simmons</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://dustycloud.org/">Christine Webber</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://wilkie.io/">Dave Wilkinson II</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://www.jasnell.me/">James Snell</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://cleverdevil.io/">Jonathan LaCour</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><span class="p-name fn">Kyle Mahan</span></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://manton.org/">Manton Reece</a></span>,
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://kodfabrik.se/">Pelle Wessman</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://aaronparecki.com/">Aaron Parecki</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://strugee.net/">AJ Jordan</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn">Benjamin Goering</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://inessential.com/">Brent Simmons</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://dustycloud.org/">Christine Webber</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://wilkie.io/">Dave Wilkinson II</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://www.jasnell.me/">James Snell</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://cleverdevil.io/">Jonathan LaCour</a></span>,
+          <span class="h-card vcard"><span class="p-name fn">Kara Mahan</span></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://manton.org/">Manton Reece</a></span>,
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://kodfabrik.se/">Pelle Wessman</a></span>,
           and 
-          <span class="h-card vcard" typeof="foaf:Person"><a class="u-url url p-name fn" property="foaf:homepage" href="https://tantek.com/">Tantek Çelik</a></span>.
+          <span class="h-card vcard"><a class="u-url url p-name fn" href="https://tantek.com/">Tantek Çelik</a></span>.
         </p>
     </section>
   </body>

--- a/index.html
+++ b/index.html
@@ -1095,7 +1095,7 @@
         <tr>
           <td>Contact: </td>
           <td>
-            Bebe Roberts &lt;<a href="mailto:ben@thatmustbe.me">ben@thatmustbe.me</a>&gt;
+            Bebe Roberts &lt;<a href="mailto:bebe@thatmustbe.me">bebe@thatmustbe.me</a>&gt;
           </td>
         </tr>
         </table>


### PR DESCRIPTION
Add authors names explicitly to informal note from the authors, update names, fix typo, remove dead URLs and markup inconsistent with (not generated by) Respec and no known current consuming uses